### PR TITLE
#3 fix grid display and filters

### DIFF
--- a/Model/ResourceModel/Order/Grid/Collection.php
+++ b/Model/ResourceModel/Order/Grid/Collection.php
@@ -40,7 +40,7 @@ class Collection extends SearchResult
      */
     public function addFieldToFilter($field, $condition = null)
     {
-        if ($field === 'products' && !$this->getFlag('product_filter_added')) {
+        if ($field === 'order_items' && !$this->getFlag('product_filter_added')) {
             // Add the sales/order_item model to this collection
             $this->getSelect()->join(
                 [$this->getTable('sales_order_item')],
@@ -61,9 +61,12 @@ class Collection extends SearchResult
             ]);
 
             $this->setFlag('product_filter_added', 1);
+
+            return $this;
+        } else {
+            return parent::addFieldToFilter($field, $condition);
         }
 
-        return parent::addFieldToFilter($field, $condition);
     }
 
     /**

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
   <p>Adds more details to the order grid in the admin.</p>
-  <img src="https://img.shields.io/badge/magento-2.2%20|%202.3-brightgreen.svg?logo=magento&longCache=true&style=flat-square" alt="Supported Magento Versions" />
+  <img src="https://img.shields.io/badge/magento-2.2%20|%202.3|%202.4-brightgreen.svg?logo=magento&longCache=true&style=flat-square" alt="Supported Magento Versions" />
   <a href="https://packagist.org/packages/markshust/magento2-module-ordergrid" target="_blank"><img src="https://img.shields.io/packagist/v/markshust/magento2-module-ordergrid.svg?style=flat-square" alt="Latest Stable Version" /></a>
   <a href="https://packagist.org/packages/markshust/magento2-module-ordergrid" target="_blank"><img src="https://poser.pugx.org/markshust/magento2-module-ordergrid/downloads" alt="Composer Downloads" /></a>
   <a href="https://GitHub.com/Naereen/StrapDown.js/graphs/commit-activity" target="_blank"><img src="https://img.shields.io/badge/maintained%3F-yes-brightgreen.svg?style=flat-square" alt="Maintained - Yes" /></a>

--- a/view/adminhtml/ui_component/sales_order_grid.xml
+++ b/view/adminhtml/ui_component/sales_order_grid.xml
@@ -1,17 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <listing xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:module:Magento_Ui:etc/ui_configuration.xsd">
-    <container name="listing_top">
-        <filters name="listing_filters">
-            <filterInput name="order_items">
-                <argument name="data" xsi:type="array">
-                    <item name="config" xsi:type="array">
-                        <item name="dataScope" xsi:type="string">order_items</item>
-                        <item name="label" xsi:type="string" translate="true">Order items</item>
-                    </item>
-                </argument>
-            </filterInput>
-        </filters>
-    </container>
     <columns name="sales_order_columns">
         <column name="order_items">
             <argument name="data" xsi:type="array">
@@ -24,6 +12,7 @@
                     <item name="align" xsi:type="string">left</item>
                     <item name="sortable" xsi:type="boolean">false</item>
                     <item name="label" xsi:type="string" translate="true">Order Items</item>
+                    <item name="filter" xsi:type="string">text</item>
                 </item>
             </argument>
         </column>


### PR DESCRIPTION
Hi @markshust,

The following PR fixes 2 issues I've found in Magento 2.4 (one of them mentioned in issue number #3 )

- Order grid styles are incorrect (I've found that it was due to the filter container in the sales_order_grid.xml file)
- Filters wouldn't work

The addFieldToFilter function had some «incoherences» (looking for a 'products' field when it was actually 'order_items'). Maybe the solution I've implemented is not the best one, but now it works fine.

I'll let you test and confirm it's ok :)