### PR TITLE
Show the name of the admin user on sales_order_grid

### DIFF
--- a/Observer/SalesOrderPlaceAfter.php
+++ b/Observer/SalesOrderPlaceAfter.php
@@ -1,0 +1,46 @@
+<?php
+
+namespace MarkShust\OrderGrid\Observer;
+
+use Magento\Framework\Event\ObserverInterface;
+
+use Magento\Backend\Model\Auth\Session;
+
+class SalesOrderPlaceAfter implements ObserverInterface
+{
+    /**
+     * @var Session
+     */
+    protected $authSession;
+
+    /**
+     * @param Session $authSession
+     */
+    public function __construct(Session $authSession)
+    {
+        $this->authSession = $authSession;
+    }
+
+    /**
+     * @param \Magento\Framework\Event\Observer $observer
+     */
+    public function execute(\Magento\Framework\Event\Observer $observer)
+    {
+        try {
+            $order = $observer->getEvent()->getOrder();
+            if(empty($order->getRemoteIp())) {
+                $adminName = $this->getCurrentUser()->getUsername();
+                $order->setData('created_by', $adminName);
+                $order->save();
+            }
+        } catch (\Exception $e) {}
+    }
+
+    /**
+     * @return \Magento\User\Model\User|null
+     */
+    private function getCurrentUser()
+    {
+        return $this->authSession->getUser();
+    }
+}

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@
 Out of the box, the Magento admin displays high-level information within the sales order grid. It does not provide more detailed information would could be useful to specific businesses.
 
 This module adds more detailed information to the admin order grid. Initially, a new column is added to the order grid which contains order line items, which includes specific quantity and product names of items ordered. 
+
 **Update** : If the order is created by any admin user, then it will show the username of the current admin in the grid with the column name "Created By"
 
 ## Installation

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-<h1 align="center">MarkShust_OrderGrid</h1> 
+<h1 align="center">MarkShust_OrderGrid Modified</h1> 
 
 <div align="center">
   <p>Adds more details to the order grid in the admin.</p>
@@ -20,7 +20,8 @@
 
 Out of the box, the Magento admin displays high-level information within the sales order grid. It does not provide more detailed information would could be useful to specific businesses.
 
-This module adds more detailed information to the admin order grid. Initially, a new column is added to the order grid which contains order line items, which includes specific quantity and product names of items ordered.
+This module adds more detailed information to the admin order grid. Initially, a new column is added to the order grid which contains order line items, which includes specific quantity and product names of items ordered. 
+**Update** : If the order is created by any admin user, then it will show the username of the current admin in the grid with the column name "Created By"
 
 ## Installation
 

--- a/etc/adminhtml/events.xml
+++ b/etc/adminhtml/events.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0"?>
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Event/etc/events.xsd">
+    <event name="sales_order_place_after">
+        <observer name="MarkShust_OrderGrid::sales_order_place_after"
+                  instance="MarkShust\OrderGrid\Observer\SalesOrderPlaceAfter" />
+    </event>
+</config>

--- a/etc/db_schema.xml
+++ b/etc/db_schema.xml
@@ -1,0 +1,10 @@
+<?xml version="1.0"?>
+<schema xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:noNamespaceSchemaLocation="urn:magento:framework:Setup/Declaration/Schema/etc/schema.xsd">
+   <table name="sales_order">
+       <column xsi:type="varchar" name="created_by" nullable="true" comment="Created By Admin User" />
+   </table>
+   <table name="sales_order_grid">
+       <column xsi:type="varchar" name="created_by" nullable="true" comment="Created By Admin User" />
+   </table>
+</schema>

--- a/etc/di.xml
+++ b/etc/di.xml
@@ -13,4 +13,11 @@
             <argument name="resourceModel" xsi:type="string">Magento\Sales\Model\ResourceModel\Order</argument>
         </arguments>
     </virtualType>
+    <virtualType name="Magento\Sales\Model\ResourceModel\Order\Grid" type="Magento\Sales\Model\ResourceModel\Grid">
+        <arguments>
+            <argument name="columns" xsi:type="array">
+                <item name="created_by" xsi:type="string">sales_order.created_by</item>
+            </argument>
+        </arguments>
+    </virtualType>
 </config>

--- a/etc/module.xml
+++ b/etc/module.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
-<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
+<config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" 
+	xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
     <module name="MarkShust_OrderGrid">
         <sequence>
             <module name="Magento_Sales" />

--- a/view/adminhtml/ui_component/sales_order_grid.xml
+++ b/view/adminhtml/ui_component/sales_order_grid.xml
@@ -16,5 +16,14 @@
                 </item>
             </argument>
         </column>
+        <column name="created_by">
+            <argument name="data" xsi:type="array">
+                <item name="config" xsi:type="array">
+                    <item name="visible" xsi:type="boolean">true</item>
+                    <item name="filter" xsi:type="string">text</item>
+                    <item name="label" xsi:type="string" translate="true">Created By</item>
+                </item>
+            </argument>
+        </column>
     </columns>
 </listing>


### PR DESCRIPTION
This PR will add a feature to show the name of the admin user on sales_order_grid, Only if the order is created by the admin. 
Column Name: Created By (created_by)

