### PR TITLE
Fixed Error on order grid page

### DIFF
--- a/Model/ResourceModel/Order/Grid/Collection.php
+++ b/Model/ResourceModel/Order/Grid/Collection.php
@@ -4,97 +4,182 @@ namespace MarkShust\OrderGrid\Model\ResourceModel\Order\Grid;
 
 use Magento\Framework\View\Element\UiComponent\DataProvider\SearchResult;
 use Magento\Sales\Model\ResourceModel\Order\Grid\Collection as OrderGridCollection;
-use Zend_Db_Expr;
 
-/**
- * Class Collection
- * @package MarkShust\OrderGrid\Model\ResourceModel\Order\Grid
- */
 class Collection extends OrderGridCollection
 {
+    private const ORDER_ITEMS_FIELD = 'order_items';
+    private const PRODUCT_FILTER_FLAG = 'product_filter_added';
+    private const SALES_ORDER_ITEM_TABLE = 'sales_order_item';
+
     /**
-     * Add field to filter.
+     * Add field to filter with special handling for order items.
      *
      * @param string|array $field
      * @param string|int|array|null $condition
      * @return Collection
      */
-    public function addFieldToFilter($field, $condition = null): Collection
-    {
-        if ($field === 'order_items' && !$this->getFlag('product_filter_added')) {
-            // Add the sales/order_item model to this collection
-            $this->getSelect()->join(
-                [$this->getTable('sales_order_item')],
-                "main_table.entity_id = {$this->getTable('sales_order_item')}.order_id",
-                []
-            );
-
-            // Group by the order id, which is initially what this grid is id'd by
-            $this->getSelect()->group('main_table.entity_id');
-
-            // On the products field, let's add the sku and name as filterable fields
-            $this->addFieldToFilter([
-                "{$this->getTable('sales_order_item')}.sku",
-                "{$this->getTable('sales_order_item')}.name",
-            ], [
-                $condition,
-                $condition,
-            ]);
-
-            $this->setFlag('product_filter_added', 1);
-
-            return $this;
-        } else {
-            return parent::addFieldToFilter($field, $condition);
+    public function addFieldToFilter(
+        $field,
+        $condition = null
+    ): Collection {
+        // Handle special case for order_items field
+        if ($field === self::ORDER_ITEMS_FIELD && !$this->getFlag(self::PRODUCT_FILTER_FLAG)) {
+            return $this->addProductFilter($condition);
         }
+
+        return parent::addFieldToFilter($field, $condition);
     }
 
     /**
-     * Perform operations after collection load.
+     * Add product-specific filtering to collection.
+     *
+     * @param array|int|string|null $condition
+     * @return Collection
+     */
+    private function addProductFilter(
+        array|int|string|null $condition
+    ): Collection {
+        $orderItemTable = $this->getTable(self::SALES_ORDER_ITEM_TABLE);
+        $orderItemAlias = 'soi';
+
+        // Join the order item table
+        $this->getSelect()->join(
+            [$orderItemAlias => $orderItemTable],
+            "main_table.entity_id = {$orderItemAlias}.order_id",
+            []
+        );
+
+        // Group by order ID to avoid duplicates
+        $this->getSelect()->group('main_table.entity_id');
+
+        // Filter by product SKU and name
+        $this->addFieldToFilter(
+            [
+                "{$orderItemAlias}.sku",
+                "{$orderItemAlias}.name",
+            ],
+            [
+                $condition,
+                $condition,
+            ]
+        );
+
+        $this->setFlag(self::PRODUCT_FILTER_FLAG, 1);
+
+        return $this;
+    }
+
+    /**
+     * Add order items data to collection after load.
      *
      * @return SearchResult
      */
     protected function _afterLoad(): SearchResult
     {
-        $items = $this->getColumnValues('entity_id');
+        $orderIds = $this->getColumnValues('entity_id');
 
-        if (count($items)) {
-            $connection = $this->getConnection();
+        if (!empty($orderIds)) {
+            $this->addOrderItemsToCollection($orderIds);
+        }
 
-            // Fetch products data separately
-            $select = $connection->select()
-                ->from([
-                    'sales_order_item' => $this->getTable('sales_order_item'),
-                ], [
+        return parent::_afterLoad();
+    }
+
+    /**
+     * Add order items HTML to each order in the collection.
+     *
+     * @param array $orderIds
+     * @return void
+     */
+    private function addOrderItemsToCollection(
+        array $orderIds
+    ): void {
+        // Get all relevant order items
+        $orderItems = $this->getOrderItems($orderIds);
+
+        // Group order items by order ID for efficient lookup
+        $productsByOrderId = $this->groupOrderItemsByOrderId($orderItems);
+
+        // Add HTML representation to each order
+        foreach ($orderIds as $orderId) {
+            if (!isset($productsByOrderId[$orderId])) {
+                continue;
+            }
+
+            $order = $this->getItemById($orderId);
+            if (!$order) {
+                continue;
+            }
+
+            $order->setData(self::ORDER_ITEMS_FIELD, $this->formatOrderItemsHtml($productsByOrderId[$orderId]));
+        }
+    }
+
+    /**
+     * Group order items by their parent order ID.
+     *
+     * @param array $orderItems
+     * @return array
+     */
+    private function groupOrderItemsByOrderId(
+        array $orderItems
+    ): array {
+        $result = [];
+
+        foreach ($orderItems as $item) {
+            $result[$item['order_id']][] = $item;
+        }
+
+        return $result;
+    }
+
+    /**
+     * Format order items as HTML.
+     *
+     * @param array $orderItems
+     * @return string
+     */
+    private function formatOrderItemsHtml(
+        array $orderItems
+    ): string {
+        $html = '';
+
+        foreach ($orderItems as $item) {
+            $html .= sprintf(
+                '<div>%d x [%s] %s</div>',
+                (int)$item['qty_ordered'],
+                $item['sku'],
+                $item['name']
+            );
+        }
+
+        return $html;
+    }
+
+    /**
+     * Get order items for the specified order IDs.
+     *
+     * @param array $orderIds
+     * @return array
+     */
+    private function getOrderItems(
+        array $orderIds
+    ): array {
+        $connection = $this->getConnection();
+
+        $select = $connection->select()
+            ->from(
+                $this->getTable(self::SALES_ORDER_ITEM_TABLE),
+                [
                     'order_id',
                     'sku',
                     'name',
                     'qty_ordered',
-                ])
-                ->where('order_id IN (?)', $items)
-                ->where('parent_item_id IS NULL'); // Eliminate configurable products, otherwise two products show
+                ]
+            )
+            ->where('order_id IN (?)', $orderIds)
+            ->where('parent_item_id IS NULL'); // Exclude child products (e.g., in configurable products)
 
-            $productData = $connection->fetchAll($select);
-
-            // Aggregate products data
-            $productsByOrderId = [];
-            foreach ($productData as $product) {
-                $productsByOrderId[$product['order_id']][] = $product;
-            }
-
-            // Loop through orders and aggregate products
-            foreach ($items as $orderId) {
-                if (isset($productsByOrderId[$orderId])) {
-                    $row = $this->getItemById($orderId);
-                    $html = '';
-                    foreach ($productsByOrderId[$orderId] as $product) {
-                        $html .= sprintf('<div>%d x [%s] %s </div>', $product['qty_ordered'], $product['sku'], $product['name']);
-                    }
-                    $row->setData('order_items', $html);
-                }
-            }
-        }
-
-        return parent::_afterLoad();
+        return $connection->fetchAll($select);
     }
 }


### PR DESCRIPTION
### Preconditions
Magento Version : 2.4.6-p2
Module Version : 1.1.1
### Related Issue
https://github.com/markshust/magento2-module-ordergrid/issues/15
### Description
Whenever we order multiple products and then attempt to visit the order grid page, an error occurs, as shown in screenshot-1.
### Screenshot-1
![image](https://github.com/markshust/magento2-module-ordergrid/assets/124759192/b657cd50-064a-4a64-aa73-dce6a075b880)
### Steps To Reproduce
1. Clone clean shop.
2. Install “MarkShust_OrderGrid” module.
3. Go to the database and perform the following query to check the maximum value of the 'GROUP_CONCAT' function.
    (SHOW VARIABLES LIKE 'group_concat_max_len';)
4. If the output is not '1024 bytes' then perform the following query to set the maximum value of 'GROUP_CONCAT' function to 
    '1024 bytes'. (SET GLOBAL group_concat_max_len = 1024;)
5. Go to the Backend->Catalog->Products.
6. Create multiple products with the long names , and make sure that total length of the combined product names goes above the maximum value of 'GROUP_CONCAT' function , which is '1024 bytes'.
(E.g. Create one simple product which allows you to make the product name upto 255 letters  , also make sure that the SKU name doesn't get above 64 letters , as it allows upto 64 letters . Now create other 4 products same as this , which has product names upto 255 letters and SKU names upto 64 letters. So that will be total 5 products. 
So the calculation will be {255*5 = 1275} , which is greater than 1024.)      
7. Visit frontend , then order those multiple products together.
8. Go to the Backend->Sales->Orders.
### Expected Result
When we try to visit the order grid page , it should display product’s details in the Order Items column on the order grid page.
### Actual Result
When we try to visit the order grid page , it shows an error as shown in screenshot-1.
### Additional Information
The issue arises due to the use of the 'GROUP_CONCAT' function in the module , as shown in screenshot-2 . As the 'GROUP_CONCAT' function comes with its default maximum value which is  '1024 bytes' . Even if we increase this limit , there is no gurantee that this error will not occur in the future . Suppose the customer orders more products at once and combinedly product names goes above the maximum value of 'GROUP_CONCAT' function . So changing the limit can't be the solution for this error. So I have removed 'GROUP_CONCAT' function and also made some changes in the following file , as you can see in this pull request. After applying this changes , the error got solved and now whenever you visit the order grid page , it will show all the product’s details in the Order Items column on the order grid page as shown in screenshot-3.
### File Name
markshust/magento2-module-ordergrid/Model/ResourceModel/Order/Grid/Collection.php
### Screenshot-2
![image](https://github.com/markshust/magento2-module-ordergrid/assets/124759192/29aad737-b443-4c66-a100-e643c9c1f7a0)
### Screenshot-3
![image](https://github.com/markshust/magento2-module-ordergrid/assets/124759192/9f1cd00f-8ed1-4207-a296-127fcefa3bb6)
